### PR TITLE
Direct Render to GDI

### DIFF
--- a/Layered2D/Interop/UnsafeNativeMethods.cs
+++ b/Layered2D/Interop/UnsafeNativeMethods.cs
@@ -135,10 +135,10 @@ namespace Layered2D.Interop
             public int bV5YPelsPerMeter;
             public uint bV5ClrUsed;
             public uint bV5ClrImportant;
-            public uint bV5RedMask;
-            public uint bV5GreenMask;
-            public uint bV5BlueMask;
-            public uint bV5AlphaMask;
+            public ColorMask bV5RedMask;
+            public ColorMask bV5GreenMask;
+            public ColorMask bV5BlueMask;
+            public ColorMask bV5AlphaMask;
             public uint bV5CSType;
             public CIEXYZTRIPLE bV5Endpoints;
             public uint bV5GammaRed;
@@ -269,6 +269,15 @@ namespace Layered2D.Interop
             DWLP_USER = 0x8,
             DWLP_MSGRESULT = 0x0,
             DWLP_DLGPROC = 0x4
+        }
+
+        [Flags]
+        public enum ColorMask : uint
+        {
+            Alpha = 0xFF000000,
+            Red = 0x00FF0000,
+            Green = 0x0000FF00,
+            Blue = 0x000000FF
         }
     }
 }

--- a/Layered2D/LayeredBuffer.cs
+++ b/Layered2D/LayeredBuffer.cs
@@ -1,27 +1,117 @@
-﻿using SkiaSharp;
+﻿using System;
+using SkiaSharp;
+using System.Runtime.InteropServices;
 using static Layered2D.Interop.UnsafeNativeMethods;
 
 namespace Layered2D
 {
     public class LayeredBuffer
     {
+        #region [ Property ]
+        public SKColorType ColorType { get; }
+        public SKAlphaType AlphaType { get; }
+        #endregion
+
+        #region [ Resources ]
         internal SKBitmap Bitmap { get; set; }
         internal RawSize Size { get; private set; }
 
+        internal IntPtr screenDc;
+        internal IntPtr memDc;
+        internal IntPtr native;
+        internal IntPtr scan0;
+        internal IntPtr oldBitmap;
+
+        internal BLENDFUNCTION blendFunc;
+        #endregion
+
+        #region [ Initializer ]
         public LayeredBuffer(int width, int height, SKColorType colorType, SKAlphaType alphaType)
         {
             this.Size = new RawSize(width, height);
+            this.ColorType = colorType;
+            this.AlphaType = alphaType;
 
-            this.Bitmap = new SKBitmap(width, height, colorType, alphaType);
+            Initialize();
         }
 
+        private void Initialize()
+        {
+            this.Bitmap = new SKBitmap();
+
+            SwapChain();
+        }
+        #endregion
+
+        #region [ User Methods ]
         public void Resize(int width, int height)
         {
             this.Size = new RawSize(width, height);
 
-            var info = this.Bitmap.Info;
-            this.Bitmap.Dispose();
-            this.Bitmap = new SKBitmap(width, height, info.ColorType, info.AlphaType);
+            ReleaseResources();
+            SwapChain();
         }
+        #endregion
+
+        #region [ Context Handling ]
+        private void SwapChain()
+        {
+            CreateNativeContext();
+
+            var info = new SKImageInfo(
+                Size.Width,
+                Size.Height,
+                SKColorType.Bgra8888,
+                SKAlphaType.Premul);
+
+            var result = this.Bitmap.InstallPixels(
+                info, scan0,
+                info.RowBytes,
+                null, null,
+                "RELEASING");
+        }
+
+        private void ReleaseResources()
+        {
+            ReleaseDC(IntPtr.Zero, screenDc);
+            SelectObject(memDc, oldBitmap);
+            DeleteDC(memDc);
+
+            DeleteObject(native);
+            DeleteObject(scan0);
+            DeleteObject(oldBitmap);
+        }
+
+        internal void CreateNativeContext()
+        {
+            var bmh = new BITMAPV5HEADER()
+            {
+                bV5Size = (uint)Marshal.SizeOf(typeof(BITMAPV5HEADER)),
+                bV5Width = Size.Width,
+                bV5Height = -Size.Height,
+                bV5Planes = 1,
+                bV5BitCount = 32,
+                bV5Compression = BitmapCompressionMode.BI_RGB,
+                bV5AlphaMask = ColorMask.Alpha,
+                bV5RedMask = ColorMask.Red,
+                bV5GreenMask = ColorMask.Green,
+                bV5BlueMask = ColorMask.Blue
+            };
+
+            blendFunc = new BLENDFUNCTION()
+            {
+                BlendOp = AC_SRC_OVER,
+                BlendFlags = 0,
+                SourceConstantAlpha = 255,
+                AlphaFormat = AC_SRC_ALPHA
+            };
+
+            screenDc = GetDC(IntPtr.Zero);
+            memDc = CreateCompatibleDC(screenDc);
+
+            native = CreateDIBSection(screenDc, ref bmh, 0, out scan0, IntPtr.Zero, 0);
+            oldBitmap = SelectObject(memDc, native);
+        }
+        #endregion
     }
 }

--- a/Layered2D/LayeredContext.cs
+++ b/Layered2D/LayeredContext.cs
@@ -1,94 +1,36 @@
 ﻿using System;
 using SkiaSharp;
-using System.Runtime.InteropServices;
 using static Layered2D.Interop.UnsafeNativeMethods;
 
 namespace Layered2D
 {
     public class LayeredContext : SKCanvas
     {
+        RawPoint emptyPoint = new RawPoint(0, 0);
+
         internal RawPoint targetPosition;
 
-        RawPoint emptyPoint = new RawPoint(0, 0);
-        RawSize screenSize;
-
-        LayeredBuffer buffer;
-        BLENDFUNCTION blendFunc;
-
         IntPtr target;
-        IntPtr native;
-        IntPtr scan0;
-        
-        IntPtr oldBitmap;
-        IntPtr screenDc;
-        IntPtr memDc;
+        LayeredBuffer buffer;
 
         public LayeredContext(IntPtr target, LayeredBuffer buffer) : base(buffer.Bitmap)
         {
             this.target = target;
             this.buffer = buffer;
-            
-            Initialize();
-        }
-
-        private void Initialize()
-        {
-            var bmh = new BITMAPV5HEADER()
-            {
-                bV5Size = (uint)Marshal.SizeOf(typeof(BITMAPV5HEADER)),
-                bV5Width = buffer.Bitmap.Width,
-                bV5Height = -buffer.Bitmap.Height,
-                bV5Planes = 1,
-                bV5BitCount = 32,
-                bV5Compression = BitmapCompressionMode.BI_RGB,
-                bV5AlphaMask = 0xFF000000,
-                bV5RedMask = 0x00FF0000,
-                bV5GreenMask = 0x0000FF00,
-                bV5BlueMask = 0x000000FF
-            };
-
-            blendFunc = new BLENDFUNCTION()
-            {
-                BlendOp = AC_SRC_OVER,
-                BlendFlags = 0,
-                SourceConstantAlpha = 255,
-                AlphaFormat = AC_SRC_ALPHA
-            };
-
-            screenSize = new RawSize(buffer.Bitmap.Width, buffer.Bitmap.Height);
-
-            screenDc = GetDC(IntPtr.Zero);
-            memDc = CreateCompatibleDC(screenDc);
-
-            native = CreateDIBSection(screenDc, ref bmh, 0, out scan0, IntPtr.Zero, 0);
-            oldBitmap = SelectObject(memDc, native);
         }
         
         public void Present()
         {
-            buffer.Bitmap.CopyPixelsTo(scan0, buffer.Bitmap.ByteCount);
-
+            var screenSize = buffer.Size;
+            
             UpdateLayeredWindow(
                 target,
-                screenDc, 
+                buffer.screenDc, 
                 ref targetPosition, ref screenSize,
-                memDc,
+                buffer.memDc,
                 ref emptyPoint, 0,
-                ref blendFunc, 
+                ref buffer.blendFunc, 
                 ULW_ALPHA);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-
-            ReleaseDC(IntPtr.Zero, screenDc);
-            SelectObject(memDc, oldBitmap);
-            DeleteDC(memDc);
-
-            DeleteObject(native);
-            DeleteObject(scan0);
-            DeleteObject(oldBitmap);
         }
     }
 }

--- a/Layered2D/Windows/LayeredWindow.cs
+++ b/Layered2D/Windows/LayeredWindow.cs
@@ -2,11 +2,11 @@
 using System.Drawing;
 using System.Windows.Forms;
 using System.ComponentModel;
+
 using SkiaSharp;
+using SkiaSharp.Views.Desktop;
 
 using WS = Layered2D.Interop.UnsafeNativeMethods.WindowStyles;
-using System.Threading;
-using SkiaSharp.Views.Desktop;
 
 namespace Layered2D.Windows
 {
@@ -176,7 +176,7 @@ namespace Layered2D.Windows
         }
 
         #endregion
-
+        
         #region [ Update ]
         protected override void OnLoad(EventArgs e)
         {
@@ -213,15 +213,12 @@ namespace Layered2D.Windows
             if (isLoaded)
             {
                 this.SuspendLayout();
-
+                
                 buffer.Resize(Width, Height);
-
-                var contextPosition = context.targetPosition;
-
+                
                 context.Dispose();
                 context = new LayeredContext(this.Handle, buffer);
-                context.targetPosition = contextPosition;
-
+                
                 this.Render();
 
                 this.NativeWidth = this.Width;


### PR DESCRIPTION
CreateDIBSection으로 만든 hBitmap 객체의 scan0를 SkBitmap에 직접 할당

SkBitmap에서 GDI Bitmap으로의 복사과정이 삭제되어

결과적으로는 캔버스에 그린 다음 바로 GDI로 렌더링이 가능.

* 1.6배의 퍼포먼스 향상.